### PR TITLE
[FEAT] : Product Image change on hover

### DIFF
--- a/app/components/ImageGallery.tsx
+++ b/app/components/ImageGallery.tsx
@@ -9,10 +9,10 @@ interface iAppProps {
 }
 
 export default function ImageGallery({ images }: iAppProps) {
-  const [bigImage, setBigImage] = useState(images[0]);
+  const [currentImage, setCurrentImage] = useState(images[0]);
 
-  const handleSmallImageClick = (image: any) => {
-    setBigImage(image);
+  const handleImageHover = (image: any) => {
+    setCurrentImage(image);
   };
   return (
     <div className="grid gap-4 lg:grid-cols-5">
@@ -25,7 +25,7 @@ export default function ImageGallery({ images }: iAppProps) {
               height={200}
               alt="photo"
               className="h-full w-full object-cover object-center cursor-pointer"
-              onClick={() => handleSmallImageClick(image)}
+              onMouseEnter={() => handleImageHover(image)}
             />
           </div>
         ))}
@@ -33,7 +33,7 @@ export default function ImageGallery({ images }: iAppProps) {
 
       <div className="relative overflow-hidden rounded-lg bg-gray-100 lg:col-span-4">
         <Image
-          src={urlFor(bigImage).url()}
+          src={urlFor(currentImage).url()}
           alt="Photo"
           width={500}
           height={500}


### PR DESCRIPTION
Fix issue: #7 

This pull request includes changes to the `ImageGallery` component in `app/components/ImageGallery.tsx` to improve the user interaction by changing the image preview behavior from click to hover.

Changes to image preview behavior:

* Renamed the state variable from `bigImage` to `currentImage` to better reflect its purpose.
* Replaced the `handleSmallImageClick` function with `handleImageHover` to update the current image on hover instead of click.
* Updated the event handler in the `img` tag to use `onMouseEnter` instead of `onClick` for changing the current image.
* Updated the `src` attribute in the main image display to use the new `currentImage` state variable.

### Video

https://github.com/user-attachments/assets/0a8ee3a1-cdf8-450a-8f92-1f36d938f7d2
